### PR TITLE
Added endian parameter and conditional generator for data resizer

### DIFF
--- a/rtl/verilog/wb_data_resize.v
+++ b/rtl/verilog/wb_data_resize.v
@@ -19,56 +19,65 @@
 module wb_data_resize
   #(parameter aw  = 32, //Address width
     parameter mdw = 32, //Master Data Width
-    parameter sdw = 8) //Slave Data Width
+    parameter sdw = 8, //Slave Data Width
+    parameter endian = "big") // Endian for byte reads/writes
    (//Wishbone Master interface
-    input  [aw-1:0]  wbm_adr_i,
-    input  [mdw-1:0] wbm_dat_i,
-    input  [3:0]     wbm_sel_i,
-    input 	     wbm_we_i,
-    input 	     wbm_cyc_i,
-    input 	     wbm_stb_i,
-    input  [2:0]     wbm_cti_i,
-    input  [1:0]     wbm_bte_i,
-    output [mdw-1:0] wbm_dat_o,
-    output 	     wbm_ack_o,
-    output 	     wbm_err_o,
-    output 	     wbm_rty_o, 
+    input   [aw-1:0]    wbm_adr_i,
+    input   [mdw-1:0]   wbm_dat_i,
+    input   [3:0]       wbm_sel_i,
+    input               wbm_we_i,
+    input               wbm_cyc_i,
+    input               wbm_stb_i,
+    input   [2:0]       wbm_cti_i,
+    input   [1:0]       wbm_bte_i,
+    output  [mdw-1:0]   wbm_dat_o,
+    output              wbm_ack_o,
+    output              wbm_err_o,
+    output              wbm_rty_o,
     // Wishbone Slave interface
-    output [aw-1:0]  wbs_adr_o,
-    output [sdw-1:0] wbs_dat_o,
-    output 	     wbs_we_o,
-    output 	     wbs_cyc_o,
-    output 	     wbs_stb_o,
-    output [2:0]     wbs_cti_o,
-    output [1:0]     wbs_bte_o,
-    input  [sdw-1:0] wbs_dat_i,
-    input 	     wbs_ack_i,
-    input 	     wbs_err_i,
-    input 	     wbs_rty_i);
+    output  [aw-1:0]    wbs_adr_o,
+    output  [sdw-1:0]   wbs_dat_o,
+    output              wbs_we_o,
+    output              wbs_cyc_o,
+    output              wbs_stb_o,
+    output  [2:0]       wbs_cti_o,
+    output  [1:0]       wbs_bte_o,
+    input   [sdw-1:0]   wbs_dat_i,
+    input               wbs_ack_i,
+    input               wbs_err_i,
+    input               wbs_rty_i);
 
    assign wbs_adr_o[aw-1:2] = wbm_adr_i[aw-1:2];
-   assign wbs_adr_o[1:0] = wbm_sel_i[3] ? 2'd0 :
-			   wbm_sel_i[2] ? 2'd1 :
-			   wbm_sel_i[1] ? 2'd2 : 2'd3;
+
+   generate if (endian == "little") begin : le_resize_gen
+      assign wbs_adr_o[1:0] = wbm_sel_i[3] ? 2'd3 :
+                              wbm_sel_i[2] ? 2'd2 :
+                              wbm_sel_i[1] ? 2'd1 : 2'd0;
+   end else begin : be_resize_gen
+      assign wbs_adr_o[1:0] = wbm_sel_i[3] ? 2'd0 :
+                              wbm_sel_i[2] ? 2'd1 :
+                              wbm_sel_i[1] ? 2'd2 : 2'd3;
+   end endgenerate
+
    assign wbs_dat_o = wbm_sel_i[3] ? wbm_dat_i[31:24] :
-		      wbm_sel_i[2] ? wbm_dat_i[23:16] :
-		      wbm_sel_i[1] ? wbm_dat_i[15:8]  :
-		      wbm_sel_i[0] ? wbm_dat_i[7:0]   : 8'b0;
-   
+                      wbm_sel_i[2] ? wbm_dat_i[23:16] :
+                      wbm_sel_i[1] ? wbm_dat_i[15:8]  :
+                      wbm_sel_i[0] ? wbm_dat_i[7:0]   : 8'b0;
+
    assign wbs_we_o  = wbm_we_i;
 
    assign wbs_cyc_o = wbm_cyc_i;
    assign wbs_stb_o = wbm_stb_i;
-   
+
    assign wbs_cti_o = wbm_cti_i;
    assign wbs_bte_o = wbm_bte_i;
-   
+
    assign wbm_dat_o = (wbm_sel_i[3]) ? {wbs_dat_i, 24'd0} :
-		      (wbm_sel_i[2]) ? {8'd0 , wbs_dat_i, 16'd0} :
-		      (wbm_sel_i[1]) ? {16'd0, wbs_dat_i, 8'd0} :
-	              {24'd0, wbs_dat_i};
+                      (wbm_sel_i[2]) ? {8'd0 , wbs_dat_i, 16'd0} :
+                      (wbm_sel_i[1]) ? {16'd0, wbs_dat_i, 8'd0} :
+                                       {24'd0, wbs_dat_i};
    assign wbm_ack_o = wbs_ack_i;
    assign wbm_err_o = wbs_err_i;
    assign wbm_rty_o = wbs_rty_i;
-   
+
 endmodule

--- a/sw/wb_intercon_gen2.py
+++ b/sw/wb_intercon_gen2.py
@@ -115,6 +115,16 @@ class WbIntercon:
         files_root = data['files_root']
         self.vlnv       = data['vlnv']
 
+        valid_endians = ['big', 'little']
+        if 'endian' in config:
+            self.endian = config['endian']
+            if self.endian not in valid_endians:
+                raise UnknownPropertyError("Unknown data resizer endian '{}' specified. Valid endians: {}".format(config['endian'], valid_endians))
+        else:
+            self.endian = "big"
+
+        print("Wishbone Data Resizer Endian: {}".format(config['endian']))
+
         for k,v in config['masters'].items():
             print("Found master " + k)
             self.masters[k] = Master(k,v)
@@ -225,6 +235,7 @@ class WbIntercon:
         parameters = [Parameter('aw', 32)]
         parameters += [Parameter('mdw', 32)]
         parameters += [Parameter('sdw', slave.datawidth)]
+        parameters += [Parameter('endian', '"{}"'.format(self.endian))]
         s = slave.name
 
         ports =[]

--- a/wb_intercon.core
+++ b/wb_intercon.core
@@ -1,6 +1,6 @@
 CAPI=2:
 
-name : ::wb_intercon:1.2.2
+name : ::wb_intercon:1.3.0
 description : Wishbone Bus Interconnect utilities
 
 filesets:


### PR DESCRIPTION
The data resizer selects the wrong address on little endian systems when trying to access 8 bit peripherals such as a 16550 UART or GPIOs.

I added an endian parameter that can be set in the `wb_intercon_gen` parameters. It defaults to big endian for backwards compatibility if unspecified.

As an example, the following generator has `endian: little` parameter which propagates to any resize instances created.

```
generate:
  wb_intercon:
    generator : wb_intercon_gen
    parameters:
      endian: little
      masters:
        ibus:
          slaves: [rom0, ram0]
        dbus:
          slaves: [rom0, ram0, uart0]
      slaves:
        rom0:
          datawidth: 32
          offset: 0x0
          size: 16384
        ram0:
          datawidth: 32
          offset: 0x80000000
          size: 8192
        uart0:
          datawidth: 8
          offset: 0x90000000
          size: 128
```