### PR TITLE
Add host parameter to the arbiter

### DIFF
--- a/rtl/verilog/wb_arbiter.v
+++ b/rtl/verilog/wb_arbiter.v
@@ -25,7 +25,8 @@
 module wb_arbiter
  #(parameter dw = 32,
    parameter aw = 32,
-   parameter num_masters = 0)
+   parameter num_hosts = 0,
+   parameter num_masters = num_hosts)
   (
    input wire			    wb_clk_i,
    input wire			    wb_rst_i,


### PR DESCRIPTION
Apply name change host/device as wb_mux.v file . Otherwise there an error for missing num_hosts parameter when using with wb_intercon_gen.